### PR TITLE
Use the global application style for TTToolButtonStyle

### DIFF
--- a/src/TabToolbar/ToolButtonStyle.cpp
+++ b/src/TabToolbar/ToolButtonStyle.cpp
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU Lesser General Public License
     along with TabToolbar.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <QApplication>
 #include <QPainter>
 #include <QStyleOptionToolButton>
 #include "ToolButtonStyle.h"

--- a/src/TabToolbar/ToolButtonStyle.cpp
+++ b/src/TabToolbar/ToolButtonStyle.cpp
@@ -21,6 +21,8 @@
 
 using namespace tt;
 
+TTToolButtonStyle::TTToolButtonStyle() : QProxyStyle(qApp->style()) {}
+
 //redefine text alignment
 void TTToolButtonStyle::drawControl(ControlElement element, const QStyleOption* opt, QPainter* p, const QWidget* widget) const
 {

--- a/src/TabToolbar/ToolButtonStyle.h
+++ b/src/TabToolbar/ToolButtonStyle.h
@@ -28,6 +28,7 @@ namespace tt
 class TTToolButtonStyle : public QProxyStyle
 {
 public:
+    TTToolButtonStyle();
     void drawControl(ControlElement element, const QStyleOption* opt, QPainter* p, const QWidget* widget) const override;
     void drawComplexControl(ComplexControl cc, const QStyleOptionComplex* opt, QPainter* p, const QWidget* widget) const override;
 };


### PR DESCRIPTION
It looks like `QProxyStyle` uses the native OS style, even if we override it in the rest of the app by setting a global `QApplication` style.

This makes `TTToolButtonStyle` respect the global `QApplication` style.